### PR TITLE
Decouple JellyGifOperation from Foundation.Operation

### DIFF
--- a/JellyGif/Source/JellyGifAnimator.swift
+++ b/JellyGif/Source/JellyGifAnimator.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 ///Methods for managing JellyGifAnimator
-public protocol JellyGifAnimatorDelegate: class {
+public protocol JellyGifAnimatorDelegate: AnyObject {
     func gifAnimatorIsReady(_ sender: JellyGifAnimator)
     
     ///Registers an UIImageView to display GIF frames
@@ -113,8 +113,8 @@ public class JellyGifAnimator {
             self?.preparingOperation = nil
         }
         
-        JellyGifAnimator.gifQueue.async {
-            self.preparingOperation?.start()
+        JellyGifAnimator.gifQueue.async { [weak self] in
+            self?.preparingOperation?.start()
         }
     }
     

--- a/JellyGif/Source/JellyGifOperation.swift
+++ b/JellyGif/Source/JellyGifOperation.swift
@@ -9,21 +9,22 @@
 import UIKit
 
 ///An operation object used to prepare information needed to start GIF animation
-public class JellyGifOperation: Operation {
+public class JellyGifOperation {
     public let inputInfo: GifInfo
     public let pixelSize: GifPixelSize
     public var completionHandler: ([UIImage], [CFTimeInterval]) -> Void
 
+    private var isCancelled = false
+  
     public init(info: GifInfo, pixelSize: GifPixelSize,
          completion: @escaping ([UIImage], [CFTimeInterval]) -> Void) {
         self.inputInfo = info
         self.pixelSize = pixelSize
         self.completionHandler = completion
-        super.init()
     }
     
-    override public func main() {
-        guard isCancelled == false else { return }
+    public func start() {
+        guard self.isCancelled == false else { return }
         
         let imageSource = CGImageSource.sourceFromInfo(inputInfo)
         let frames = imageSource?.frameDurations ?? []
@@ -40,5 +41,9 @@ public class JellyGifOperation: Operation {
             guard self?.isCancelled == false else { return }
             self?.completionHandler(images, frames)
         }
+    }
+  
+    public func cancel() {
+      self.isCancelled = true
     }
 }


### PR DESCRIPTION
This PR addresses the following crash:

     Crashed: custom.jelly.gif.animator.queue
     0  libobjc.A.dylib                0x2474 objc_msgSend + 20
     1  Foundation                     0x11fa6c +[__NSOperationInternalObserver _observeValueForKeyPath:ofObject:changeKind:oldValue:newValue:indexes:context:] + 356
     2  Foundation                     0x1def0 -[NSOperation start] + 1196
     3  JellyGif                       0xb764 partial apply for closure #2 in JellyGifAnimator.prepareAnimation() + 4321490788 (<compiler-generated>:4321490788)
     4  JellyGif                       0xaeb8 thunk for @escaping @callee_guaranteed () -> () + 4321488568 (<compiler-generated>:4321488568)

As discussed in https://github.com/TaLinh/JellyGif/issues/8